### PR TITLE
Resolve double start

### DIFF
--- a/jumpstarter/__init__.py
+++ b/jumpstarter/__init__.py
@@ -1,1 +1,4 @@
 __version__ = "0.1.0"
+from .actors import Actor
+
+__all__ = ("Actor",)

--- a/tests/test_actors.py
+++ b/tests/test_actors.py
@@ -163,7 +163,7 @@ async def test_resource_unavailable():
     assert fake_actor.resource is None
 
 
-async def test_actor_can_transition_back_to_starting_after_stopped():
+async def test_actor_can_transition_back_to_started_after_stopped():
     class FakeActor(Actor):
         ...
 
@@ -178,4 +178,4 @@ async def test_actor_can_transition_back_to_starting_after_stopped():
     assert fake_actor.state == ActorState.stopped
 
     await fake_actor.start()
-    assert fake_actor.state == ActorState.starting
+    assert fake_actor.state == ActorState.started


### PR DESCRIPTION
This resolves the ability to transition from `stopped` state to `started` state with a single `.start()` trigger.