### PR TITLE
Actor crashed state

### DIFF
--- a/jumpstarter/states.py
+++ b/jumpstarter/states.py
@@ -255,7 +255,6 @@ class ActorStateMachine(BaseStateMachine):
                 auto_transitions=False,
                 send_event=True,
                 name=name,
-                # queued=True,
                 model_attribute="_state",
                 finalize_event=_crash_if_an_error_occurred,
             )
@@ -266,8 +265,8 @@ class ActorStateMachine(BaseStateMachine):
                 auto_transitions=False,
                 send_event=True,
                 name=name,
-                queued=True,
                 model_attribute="_state",
+                finalize_event=_crash_if_an_error_occurred,
             )
 
             self._create_bootup_transitions(actor_state)

--- a/tests/actors/test_actor_resources.py
+++ b/tests/actors/test_actor_resources.py
@@ -97,6 +97,8 @@ async def test_acquire_async_resource_timed_out(subtests):
         async with anyio.create_task_group() as tg:
             await fake_actor.start(tg)
 
+    assert fake_actor.state == ActorState.crashed
+
 
 async def test_acquire_sync_resource_timeout_not_supported(subtests):
     resource_mock = MagicMock()
@@ -114,6 +116,8 @@ async def test_acquire_sync_resource_timeout_not_supported(subtests):
         async with anyio.create_task_group() as tg:
             await fake_actor.start(tg)
 
+    assert fake_actor.state == ActorState.crashed
+
 
 async def test_acquire_resource_not_a_resource(subtests):
     class FakeActorWithAFaultyResource(Actor):
@@ -130,6 +134,8 @@ async def test_acquire_resource_not_a_resource(subtests):
     ):
         await a.start()
 
+    assert a.state == ActorState.crashed
+
 
 async def test_acquire_resource_within_specified_timeout_not_a_resource(subtests):
     class FakeActorWithAFaultyResource(Actor):
@@ -145,6 +151,8 @@ async def test_acquire_resource_within_specified_timeout_not_a_resource(subtests
         r"Instead we got <object object at 0x[0-9a-f]+>\.",
     ):
         await a.start()
+
+    assert a.state == ActorState.crashed
 
 
 async def test_resource_is_immutable():


### PR DESCRIPTION
Whenever the actor crashes during its lifecycle, it will transition to the crashed state and provide the exception that was raised that made it crash.